### PR TITLE
Fix property 'isClearable' passing to react-select components

### DIFF
--- a/src/client/components/Async/Async.react.js
+++ b/src/client/components/Async/Async.react.js
@@ -7,6 +7,7 @@ import MenuPortal from '../MenuPortal__fix.react';
 export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
   <AsyncSelect
     ref={innerRef}
+    isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}

--- a/src/client/components/AsyncCreatable/AsyncCreatable.react.js
+++ b/src/client/components/AsyncCreatable/AsyncCreatable.react.js
@@ -7,6 +7,7 @@ import MenuPortal from '../MenuPortal__fix.react';
 export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
   <ReactAsyncCreatable
     ref={innerRef}
+    isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}

--- a/src/client/components/Creatable/Creatable.react.js
+++ b/src/client/components/Creatable/Creatable.react.js
@@ -7,6 +7,7 @@ import MenuPortal from '../MenuPortal__fix.react';
 export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
   <ReactCreatable
     ref={innerRef}
+    isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}

--- a/src/client/components/Select/Select.react.js
+++ b/src/client/components/Select/Select.react.js
@@ -7,6 +7,7 @@ import MenuPortal from '../MenuPortal__fix.react';
 export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
   <ReactSelect
     ref={innerRef}
+    isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}


### PR DESCRIPTION
__Motivation:__
The prop `isClearable` was not passed to the underlying react-select components.

__Changes in this PR:__
- For each react-select component, the property `isClearable` is explicitly passed to the underlying component. This will preserve the default value setting for said prop as it has been previously, while still providing the prop to the underlying components.