### PR TITLE
Merge styles prop with default styles instead of replacing entirely

### DIFF
--- a/src/client/components/Async/Async.DOCUMENTATION.md
+++ b/src/client/components/Async/Async.DOCUMENTATION.md
@@ -29,16 +29,10 @@ See documentation of [react-select](https://github.com/JedWatson/react-select)
             const customStyles = {};
             if (data.statusId === '700') {
               customStyles.backgroundColor = "#ccc";
-            } else {
-              customStyles.backgroundColor = "white";
             }
             return {
               ...styles,
-              ...customStyles,
-              ':active': {
-                ...styles[':active'],
-                backgroundColor: data.statusId === '700' ? "#ccc" : "white",
-              },
+              ...customStyles
             }
           }
         }}

--- a/src/client/components/Async/Async.react.js
+++ b/src/client/components/Async/Async.react.js
@@ -3,16 +3,16 @@ import React from 'react';
 import AsyncSelect from 'react-select/lib/Async';
 import '../Select/SelectCustom.less';
 import MenuPortal from '../MenuPortal__fix.react';
-import defaultStyles from '../defaultStyles';
+import { mergeDefaultStyles } from '../defaultStyles';
 
-export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
+export default ({ innerRef = () => {}, className = '', isClearable = true, styles, ...restProps }) => (
   <AsyncSelect
     ref={innerRef}
     isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}
-    {...defaultStyles}
+    styles={mergeDefaultStyles(styles)}
     {...restProps}
   />
 );

--- a/src/client/components/AsyncCreatable/AsyncCreatable.react.js
+++ b/src/client/components/AsyncCreatable/AsyncCreatable.react.js
@@ -3,16 +3,16 @@ import React from 'react';
 import ReactAsyncCreatable from 'react-select/lib/AsyncCreatable';
 import '../Select/SelectCustom.less';
 import MenuPortal from '../MenuPortal__fix.react';
-import defaultStyles from '../defaultStyles';
+import { mergeDefaultStyles } from '../defaultStyles';
 
-export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
+export default ({ innerRef = () => {}, className = '', isClearable = true, styles, ...restProps }) => (
   <ReactAsyncCreatable
     ref={innerRef}
     isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}
-    {...defaultStyles}
+    styles={mergeDefaultStyles(styles)}
     {...restProps}
   />
 );

--- a/src/client/components/Creatable/Creatable.react.js
+++ b/src/client/components/Creatable/Creatable.react.js
@@ -3,16 +3,16 @@ import React from 'react';
 import ReactCreatable from 'react-select/lib/Creatable';
 import '../Select/SelectCustom.less';
 import MenuPortal from '../MenuPortal__fix.react';
-import defaultStyles from '../defaultStyles';
+import { mergeDefaultStyles } from '../defaultStyles';
 
-export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
+export default ({ innerRef = () => {}, className = '', isClearable = true, styles, ...restProps }) => (
   <ReactCreatable
     ref={innerRef}
     isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}
-    {...defaultStyles}
+    styles={mergeDefaultStyles(styles)}
     {...restProps}
   />
 );

--- a/src/client/components/Select/Select.react.js
+++ b/src/client/components/Select/Select.react.js
@@ -3,16 +3,16 @@ import React from 'react';
 import ReactSelect from 'react-select';
 import './SelectCustom.less';
 import MenuPortal from '../MenuPortal__fix.react';
-import defaultStyles from '../defaultStyles';
+import { mergeDefaultStyles } from '../defaultStyles';
 
-export default ({ innerRef = () => {}, className = '', isClearable = true, ...restProps }) => (
+export default ({ innerRef = () => {}, className = '', isClearable = true, styles, ...restProps }) => (
   <ReactSelect
     ref={innerRef}
     isClearable={isClearable}
     className={`opuscapita_react-select--2-0-0 ${className}`}
     classNamePrefix="opuscapita_react-select"
     components={{ MenuPortal }}
-    {...defaultStyles}
+    styles={mergeDefaultStyles(styles)}
     {...restProps}
   />
 );

--- a/src/client/components/defaultStyles.js
+++ b/src/client/components/defaultStyles.js
@@ -1,14 +1,15 @@
-export default {
-  styles: {
-    option: (styles) => {
-      return {
-        ...styles,
-        backgroundColor: 'white',
-        ':active': {
-          ...styles[':active'],
-          backgroundColor: "white",
-        },
-      }
+import { mergeStyles } from 'react-select';
+
+const defaultStyles = {
+  option: (styles, { isSelected, isFocused }) => {
+    return {
+      ...styles,
+      backgroundColor:
+        isSelected ? 'rgba(0, 126, 255, 0.04)'
+        : isFocused ? 'rgba(0, 126, 255, 0.08)'
+        : '#ffffff',
     }
   }
 }
+
+export const mergeDefaultStyles = styles => mergeStyles(defaultStyles, styles);

--- a/src/client/components/defaultStyles.js
+++ b/src/client/components/defaultStyles.js
@@ -5,9 +5,9 @@ const defaultStyles = {
     return {
       ...styles,
       backgroundColor:
-        isSelected ? 'rgba(0, 126, 255, 0.04)'
-        : isFocused ? 'rgba(0, 126, 255, 0.08)'
-        : '#ffffff',
+        isSelected ? 'rgba(0, 126, 255, 0.04)' :
+        isFocused ? 'rgba(0, 126, 255, 0.08)' :
+        '#ffffff',
     }
   }
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,4 @@
-import { components, createFilter, mergeStyles } from 'react-select';
+import { components, createFilter } from 'react-select';
 import Select from './components/Select';
 import Async from './components/Async';
 import AsyncCreatable from './components/AsyncCreatable';
@@ -14,6 +14,5 @@ export {
 	AsyncCreatable,
 	Creatable,
 	components,
-	createFilter,
-	mergeStyles
+	createFilter
 };


### PR DESCRIPTION
Why:
- a portion of default styles was deleted in https://github.com/OpusCapita/react-select/commit/f8208d9252b55372a9968c2fd817930e5390f41a#diff-6c863990ba04b600d84f36ef3a231b44L155-L160 - this PR restores these styles
- avoid replacing default styles entirely. This PR makes it so component merges incoming `styles` props with default styles using [mergeStyles](https://github.com/JedWatson/react-select/blob/cba15309c4d7523ab6a785c8d5c0c7ec1048e22f/packages/react-select/src/styles.js#L93) function from original `react-select` API